### PR TITLE
Update .smalltalk.ston

### DIFF
--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -7,5 +7,8 @@ SmalltalkCISpec {
       #onWarningLog : true,
       #platforms : [ #gemstone, #pharo ]
     }
-  ]
+  ],
+  #testing : {
+    #failOnZeroTests : false
+  }
 }


### PR DESCRIPTION
That way you can remove the server-side GtGsInspectorGemstoneTests>>#testThatAlwaysPasses and still pass travis builds. Of course if  GtGsInspectorGemstoneTests>>#testThatAlwaysPasses is serving another purpose then **never mind:)**